### PR TITLE
Focus the dialog by default

### DIFF
--- a/dialog.js
+++ b/dialog.js
@@ -32,22 +32,6 @@ angular.module('ayDialog', [])
 
     var kZIndexMax = Math.pow(2, 31) - 1;
 
-    // Courtesy of AngularUI Bootstrap's $modal service
-    var FOCUS_SELECTOR = [
-        'a[href]',
-        'area[href]',
-        'input:not([disabled])',
-        'button:not([disabled])',
-        'select:not([disabled])',
-        'textarea:not([disabled])',
-        'keygen:not([disabled])',
-        'iframe',
-        'object',
-        'embed',
-        '[tabindex]:not([disabled]):not([tabindex=""])',
-        '[contenteditable=true]'
-    ].join(',');
-
 
     var DIALOG_STYLES = [
         '[hidden] {',
@@ -73,6 +57,10 @@ angular.module('ayDialog', [])
         '    visibility: hidden;',
         '    overflow: auto;',
         '    -webkit-overflow-scrolling: touch;',
+        '}',
+        '',
+        'dialog:focus {',
+        '    outline: 0 none;',
         '}',
         '',
         'dialog[open] {',
@@ -112,21 +100,6 @@ angular.module('ayDialog', [])
         var control = el.querySelector('[autofocus]:not([disabled])');
 
         if (control && !skipauto) {
-            if (immediate) {
-                control.focus();
-                return;
-            }
-
-            $window.setTimeout(function() {
-                control.focus();
-            }, 1);
-            el.focus();
-            return;
-        }
-
-        var control = el.querySelector(FOCUS_SELECTOR);
-
-        if (control) {
             if (immediate) {
                 control.focus();
                 return;
@@ -310,6 +283,11 @@ angular.module('ayDialog', [])
             // Set the aria-role to dialog (even if natively supported)
             if (!el.hasAttribute('role')) {
                 el.setAttribute('role', 'dialog');
+            }
+
+            // Ensure the dialog is focusable
+            if (!el.hasAttribute('tabindex')) {
+                el.tabIndex = -1;
             }
 
 


### PR DESCRIPTION
Implements the proposed spec changes discussed in https://github.com/whatwg/html/issues/1929 to focus the dialog element itself, rather than the first focusable child (unless there is a child with the `autofocus` attribute).

A summary of that WHATWG bug is that screenreaders and other assistive technologies give much more useful output when the dialog itself is focus on opening, and the automatic focus led to unexpected results when combined with tabindex.

In our case, this will fix the problems we've had with outlines and backgrounds showing on dialog close buttons due to automatic focusing.


I'm not entirely clear whether this should be merged ahead of the spec solidifying, but it does solve a real bug in our case.