### PR TITLE
Fix scroll position in Chrome when dialog opens

### DIFF
--- a/dialog.js
+++ b/dialog.js
@@ -302,7 +302,8 @@ angular.module('ayDialog', [])
                 // dialogs are open.
                 var showModal = HTMLDialogElement.prototype.showModal;
                 el.showModal = function(anchor) {
-                    restoreScroll = blockScrolling();
+                    var offset = getScrollOffset();
+                    restoreScroll = blockScrolling(offset);
                     dialogStack.push(el);
 
                     requestAnimationFrame(function() {


### PR DESCRIPTION
The code around scrollblocking was updated a while back for iOS such that the offset needed to be calculated earlier and passed in as a parameter. Unfortunately, the branch for browsers that support `dialog` natively was never updated.

This fixes the bug where opening a dialog causes the page to scroll to the top and then jump back down when the dialog is closed, rather than sticking at the current scroll position.