### PR TITLE
Fix for dynamically constructed modal dialogs

### DIFF
--- a/dialog.js
+++ b/dialog.js
@@ -473,7 +473,7 @@ angular.module('ayDialog', [])
 
                 el.hidden = false;
 
-                if (!sentinel) {
+                if (parentNode && !sentinel) {
                     sentinel = $window.document.createElement('dialog-sentinel');
                     parentNode.insertBefore(sentinel, el);
                 }


### PR DESCRIPTION
These dialog elements are compiled before being attached to the DOM, so the parentNode is null at directive initialization time.  Luckily, these dialogs are also always appended to the body of the page, so we don't actually need the sentinel node in that case.