### PR TITLE
Restore scrolling on destroy

### DIFF
--- a/dialog.js
+++ b/dialog.js
@@ -333,6 +333,7 @@ angular.module('ayDialog', [])
                         checkUnblockScrolling();
                     }
 
+                    restoreScroll();
                     el.removeEventListener('close', checkUnblockScrolling);
                     el.removeEventListener('cancel', checkUnblockScrolling);
                     el = null;


### PR DESCRIPTION
The close listener gets removed when the element gets destroyed.  We want to make sure we're restoring the scrolling at this time. 