### PR TITLE
Fix removing dialog when sentinel is removed

### DIFF
--- a/src/dialog_element.ts
+++ b/src/dialog_element.ts
@@ -522,6 +522,7 @@ Object.defineProperty(AyDialogElement.prototype, 'showModal', {
 
     if (!sentinelMap.has(this)) {
       const sentinel = this.ownerDocument!.createElement('dialog-sentinel');
+      (sentinel as any).dialogOwner = this;
       parentNode.insertBefore(sentinel, this);
 
       sentinelMap.set(this, sentinel);

--- a/src/polyfill.ts
+++ b/src/polyfill.ts
@@ -98,6 +98,11 @@ function augmentElements(mutationList : Array<MutationRecord> | null, _obs: Muta
           for (let k = 0; k < children.length; k++) {
             DialogElement.prototype.disconnectedCallback.call(children[k]);
           }
+
+          const sentinels = el.querySelectorAll<HTMLElement>('dialog-sentinel');
+          for (let k = 0; k < sentinels.length; k++) {
+            (sentinels[k] as any).dialogOwner.remove();
+          }
         }
       }
     }

--- a/tests/README.md
+++ b/tests/README.md
@@ -100,6 +100,11 @@ spec yet.
     This includes the polyfill with additions and verifies that the dialog
     receives focus.
 
+* xspec-dialog-showModal-removal.html
+    This includes the polyfill (sans additions) and verifies that if a dialog's
+    containing element is removed while the dialog is open, the sentinel node
+    properly causes the dialog to be removed from the page as well.
+
 * xspec-focus-after-close.html
     This includes the polyfill with additions and verifies that focus is
     returned to the previous element when the dialog is closed.

--- a/tests/xspec-dialog-showModal-remove.html
+++ b/tests/xspec-dialog-showModal-remove.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>dialog element: removing from document after showModal()</title>
+<link rel=help href="https://html.spec.whatwg.org/multipage/interactive-elements.html#dom-dialog-showmodal">
+<link rel=help href="https://fullscreen.spec.whatwg.org/#removing-steps">
+<script src="./dist/polyfill.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="container">
+  <dialog></dialog>
+</div>
+<script>
+async_test(function(t) {
+  const container = document.getElementById('container');
+  const dialog = document.querySelector('dialog')
+  dialog.showModal()
+  assert_true(dialog.open)
+  // The dialog element is now in top layer. Removing it should synchronously
+  // remove it from top layer, but should leave it in a strange limbo state.
+  dialog.addEventListener('close', t.unreached_func('close event'))
+  container.remove()
+  assert_true(dialog.open)
+  // if an event was queued, it would fire before this timeout
+  step_timeout(t.step_func_done(function() {
+    assert_true(dialog.open)
+    assert_false(dialog.isConnected)
+    // pass if no close event was fired
+  }))
+})
+</script>
+


### PR DESCRIPTION
Because we shuffle the dialog around in the DOM for proper top-layer positioning, if its containing element were removed while it was being displayed it would not be closed properly. The most common instance for this happening is in a single-page app where a button or link in a dialog is used to navigate to a new page. The dialog's original containing node would be removed as part of the page navigation but the dialog itself would not be.

We now detect when the sentinel element is removed, and also remove the corresponding dialog. A new (non-spec) test case verifies this behaviour.