### PR TITLE
Minor syntax fixes to keep IE11 compat

### DIFF
--- a/src/dialog_additions.ts
+++ b/src/dialog_additions.ts
@@ -98,8 +98,8 @@ function captureScrollState(dialog : HTMLDialogElement) {
 
   if (beforeTop.scrollHeight > document.documentElement.clientHeight) {
     beforeTop.style.position = 'fixed';
-    beforeTop.style.left = `${-scrollLeft}px`;
-    beforeTop.style.top = `${-scrollTop}px`;
+    beforeTop.style.left = -scrollLeft + 'px';
+    beforeTop.style.top = -scrollTop + 'px';
   }
 
   topLayerStack.push(dialog);
@@ -113,7 +113,10 @@ function restoreScrollState(dialog : HTMLDialogElement) {
 
   const newTop = topLayerStack[topLayerStack.length - 1];
   if (idx >= 0 && scrollPosMap.has(newTop)) {
-    const [scrollTop, scrollLeft, style] = scrollPosMap.get(newTop)!;
+    const fields = scrollPosMap.get(newTop)!;
+    const scrollTop = fields[0];
+    const scrollLeft = fields[1];
+    const style = fields[2];
 
     if (style) {
       newTop.setAttribute('style', style);

--- a/src/dialog_element.ts
+++ b/src/dialog_element.ts
@@ -394,7 +394,8 @@ function checkInertFocus(evt : FocusEvent) {
 
     // Edge case where a dialog is removed and then code is run before the
     // mutation observer kicks in
-    if (topEl.isConnected) {
+    const connected = (('isConnected' in topEl) && topEl.isConnected) || (topEl.ownerDocument!.documentElement.contains(topEl));
+    if (connected) {
       break;
     }
   }

--- a/src/polyfill.ts
+++ b/src/polyfill.ts
@@ -93,7 +93,8 @@ function augmentElements(mutationList : Array<MutationRecord> | null, _obs: Muta
           DialogElement.prototype.disconnectedCallback.call(el as HTMLDialogElement);
         }
 
-        if (!el.isConnected) {
+        const connected = (('isConnected' in el) && el.isConnected) || (el.ownerDocument!.documentElement.contains(el));
+        if (!connected) {
           const children = el.querySelectorAll<HTMLDialogElement>('dialog[__defined]');
           for (let k = 0; k < children.length; k++) {
             DialogElement.prototype.disconnectedCallback.call(children[k]);

--- a/tests/xspec-dialog-showModal-remove.html
+++ b/tests/xspec-dialog-showModal-remove.html
@@ -18,12 +18,16 @@ async_test(function(t) {
   // The dialog element is now in top layer. Removing it should synchronously
   // remove it from top layer, but should leave it in a strange limbo state.
   dialog.addEventListener('close', t.unreached_func('close event'))
-  container.remove()
+  container.parentNode.removeChild(container)
   assert_true(dialog.open)
   // if an event was queued, it would fire before this timeout
   step_timeout(t.step_func_done(function() {
     assert_true(dialog.open)
-    assert_false(dialog.isConnected)
+    if ('isConnected' in dialog) {
+      assert_false(dialog.isConnected)
+    } else {
+      assert_false(dialog.ownerDocument.documentElement.contains(dialog))
+    }
     // pass if no close event was fired
   }))
 })


### PR DESCRIPTION
Arguably, I could just tell TypeScript to spit out ES5, and the only difference is `const`/`let` turning into `var`, but there was probably some reason for setting it up to output ES6